### PR TITLE
Better attrs

### DIFF
--- a/src/rust/expression/grammar.pest
+++ b/src/rust/expression/grammar.pest
@@ -20,7 +20,7 @@ call_arg = _{ kw_arg | pos_arg }
 pos_arg = { expression }
 kw_arg = { ident ~ whitespace* ~ "=" ~ whitespace* ~ expression }
 
-primary = _{ "(" ~ expression ~ ")" | component | ident | string | integer | boolean }
+primary = _{ "(" ~ expression ~ ")" | component | string | integer | boolean | ident }
 component = { "<" ~ (!"/>" ~ ANY)* ~ "/>" }
 
 operator = { "+" | "-" | "*" | "/" | "and" | "or" | "==" | "!=" | ">=" | "<=" | ">" | "<" }
@@ -28,9 +28,10 @@ boolean = { "true" | "false" }
 integer = @{ (ASCII_DIGIT | "_")+ }
 string = @{ "\"" ~ (escape_sequence | !("\"" | "\\") ~ ANY)* ~ "\"" }
 
-keyword = { "for" | "in" | "if" | "else" | "not" | operator | boolean | "{" | "}" | "[" | "]" }
+keyword = { "for" | "in" | "if" | "else" | "not" | "and" | "or" }
 
-ident = { !keyword ~ ident_raw }
+keyword_spaced = { keyword ~ (whitespace+ | ".") }
+ident = { !keyword_spaced ~ ident_raw }
 ident_raw = _{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
 
 whitespace = _{ " " | "\t" | "\n" | "\r" | comment_expression }

--- a/src/rust/markup/grammar.pest
+++ b/src/rust/markup/grammar.pest
@@ -25,7 +25,7 @@ comment   = { "<!--" ~ (!"-->" ~ ANY)* ~ "-->" }
 expression = { "{" ~ (expression | (!"}" ~ ANY))* ~ "}" }
 
 ident = @{ ASCII_ALPHANUMERIC ~ (ASCII_ALPHANUMERIC | "_" )* }
-attr_name = @{ (ASCII_ALPHANUMERIC | "_" | "-")+ }
+attr_name = @{ (ASCII_ALPHA | "_" ) ~ (ASCII_ALPHANUMERIC | "_" | "-" | ":" | "." )* }
 attr_value = @{ string_literal_quote | string_literal_doublequote | expression }
 
 string_literal_doublequote = _{ "\"" ~ (!"\"" ~ ANY)* ~ "\"" }

--- a/src/rust/markup/tokens.rs
+++ b/src/rust/markup/tokens.rs
@@ -127,6 +127,7 @@ impl ToHtml for XElement {
                     .copy()?;
 
                 for (name, attrnode) in self.attrs() {
+                    let name = name.replace('-', "_");
                     if let XNode::Expression(ref expression) = attrnode {
                         let node_attr_v =
                             eval_expression(py, expression.expression(), &catalog, context)?;

--- a/src/rust/markup/tokens.rs
+++ b/src/rust/markup/tokens.rs
@@ -127,7 +127,10 @@ impl ToHtml for XElement {
                     .copy()?;
 
                 for (name, attrnode) in self.attrs() {
-                    let name = name.replace('-', "_");
+                    let name = name
+                        .replace('-', "_")
+                        .replace("class", "class_")
+                        .replace("for", "for_");
                     if let XNode::Expression(ref expression) = attrnode {
                         let node_attr_v =
                             eval_expression(py, expression.expression(), &catalog, context)?;

--- a/tests/unittests/test_render_attributes.py
+++ b/tests/unittests/test_render_attributes.py
@@ -24,6 +24,21 @@ def Form(
     """
 
 
+@catalog.component
+def Label(
+    for_: str | None = None,
+    class_: str | None = None,
+) -> str:
+    return """
+        <label
+            for={for_}
+            class={class_}
+            >
+            { children }
+        </label>
+    """
+
+
 @pytest.mark.parametrize(
     "component,expected",
     [
@@ -41,12 +56,23 @@ def Form(
         pytest.param(
             catalog.render("<Form hx_target='/ajax'><input/></Form>"),
             '<form hx-target="/ajax"><input/></form>',
-            id="drop-none",
+            id="forward hx_target",
         ),
         pytest.param(
             catalog.render("<Form hx-target='/ajax'><input/></Form>"),
             '<form hx-target="/ajax"><input/></form>',
-            id="drop-none",
+            id="forward hx-target",
+        ),
+        # we don't test multiple attributes since rust hashmap are not ordered
+        pytest.param(
+            catalog.render("<Form><Label class='p-4'>Name:</Label></Form>"),
+            '<form><label class="p-4">Name:</label></form>',
+            id="forward class and for",
+        ),
+        pytest.param(
+            catalog.render("<Form><Label for='name'>Name:</Label></Form>"),
+            '<form><label for="name">Name:</label></form>',
+            id="forward class and for",
         ),
     ],
 )

--- a/tests/unittests/test_render_attributes.py
+++ b/tests/unittests/test_render_attributes.py
@@ -38,6 +38,16 @@ def Form(
         pytest.param(
             Form(method="post"), '<form method="post"></form>', id="add-kwargs"
         ),
+        pytest.param(
+            catalog.render("<Form hx_target='/ajax'><input/></Form>"),
+            '<form hx-target="/ajax"><input/></form>',
+            id="drop-none",
+        ),
+        pytest.param(
+            catalog.render("<Form hx-target='/ajax'><input/></Form>"),
+            '<form hx-target="/ajax"><input/></form>',
+            id="drop-none",
+        ),
     ],
 )
 def test_render_form(component: str, expected: str):


### PR DESCRIPTION
Improve attributes.

replace hyphen by underscore for python mapping
fix usage of for and class that has to be mappted to for_ and class_ vars